### PR TITLE
Version update to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.2.1] - 2017-10-01
 ## Changed
 - Running a service with an action input payload now flushes the output
   right after the print.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Changed
 - Running a service with an action input payload now flushes the output
   right after the print.
+- File payload have a name and is now added to transport as a list of
+  files instead of a dict.
 
 ## [1.2.0] - 2017-09-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Changed
+- Running a service with an action input payload now flushes the output
+  right after the print.
 
 ## [1.2.0] - 2017-09-01
 ### Fixed

--- a/katana/__init__.py
+++ b/katana/__init__.py
@@ -12,4 +12,4 @@ file that was distributed with this source code.
 
 __license__ = "MIT"
 __copyright__ = "Copyright (c) 2016-2017 KUSANAGI S.L. (http://kusanagi.io)"
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/katana/api/action.py
+++ b/katana/api/action.py
@@ -251,14 +251,22 @@ class Action(Api):
         version = self.get_version()
         action_name = self.get_action_name()
 
-        # Get files for current service, version and action
+        # Get files for current service, version and action and save
+        # them in a dictionary where the keys are the file parameter
+        # name and the value the file payload.
         path = 'files|{}|{}|{}|{}'.format(
             self.__gateway[1],
             nomap(service),
             version,
             nomap(action_name),
             )
-        self.__files = transport.get(path, default={}, delimiter='|')
+        self.__files = {}
+        for file in transport.get(path, default=[], delimiter='|'):
+            name = get_path(file, 'name', None)
+            if not name:
+                continue
+
+            self.__files[name] = file
 
         # Get schema for current action
         try:
@@ -295,14 +303,14 @@ class Action(Api):
             # to true.
             has_file_server = True
 
-        files_payload = {}
+        files_list = []
         for file in files:
             if file.is_local() and not has_file_server:
                 raise NoFileServerError(self.get_name(), self.get_version())
 
-            files_payload[file.get_name()] = file_to_payload(file)
+            files_list.append(file_to_payload(file))
 
-        return files_payload
+        return files_list
 
     def is_origin(self):
         """Determines if the current service is the origin of the request.
@@ -457,7 +465,7 @@ class Action(Api):
         """
 
         if self.has_file(name):
-            return payload_to_file(name, self.__files[name])
+            return payload_to_file(self.__files[name])
         else:
             return File(name, path='')
 
@@ -469,8 +477,8 @@ class Action(Api):
         """
 
         files = []
-        for name, payload in self.__files.items():
-            files.append(payload_to_file(name, payload))
+        for payload in self.__files.values():
+            files.append(payload_to_file(payload))
 
         return files
 

--- a/katana/api/file.py
+++ b/katana/api/file.py
@@ -37,6 +37,7 @@ def file_to_payload(file):
     """
 
     return Payload().set_many({
+        'name': file.get_name(),
         'path': file.get_path(),
         'mime': file.get_mime(),
         'filename': file.get_filename(),
@@ -45,11 +46,9 @@ def file_to_payload(file):
         })
 
 
-def payload_to_file(name, payload):
+def payload_to_file(payload):
     """Convert payload to a File.
 
-    :param name: File field name.
-    :type name: str
     :param payload: A payload object.
     :type payload: dict
 
@@ -59,7 +58,7 @@ def payload_to_file(name, payload):
 
     # All files created from payload data are remote
     return File(
-        name,
+        get_path(payload, 'name'),
         get_path(payload, 'path'),
         mime=get_path(payload, 'mime', None),
         filename=get_path(payload, 'filename', None),

--- a/katana/api/transport.py
+++ b/katana/api/transport.py
@@ -116,7 +116,7 @@ class Transport(object):
         """
 
         if self.has_download():
-            return payload_to_file('download', self.__transport.get('body'))
+            return payload_to_file(self.__transport.get('body'))
 
     def get_data(self, address=None, service=None, version=None, action=None):
         """Get data from Transport.

--- a/katana/server.py
+++ b/katana/server.py
@@ -365,7 +365,7 @@ class ComponentServer(object):
             raise KatanaError(error)
 
         output = serialize(payload, prettify=True).decode('utf8')
-        print(output)
+        print(output, flush=True)
 
     @asyncio.coroutine
     def listen(self, channel):

--- a/tests/api/http/test_http_request.py
+++ b/tests/api/http/test_http_request.py
@@ -140,7 +140,8 @@ def test_api_http_request_files():
     assert file.get_path() == ''
 
     # Create a request with a file
-    file = payload_to_file('test', {
+    file = payload_to_file({
+        'name': 'test',
         'path': '/files',
         'mime': 'application/json',
         'filename': 'test.json',

--- a/tests/api/test_action.py
+++ b/tests/api/test_action.py
@@ -589,10 +589,10 @@ def test_api_action_defer_call(read_json, registry):
     files = [action.new_file('download', '/tmp/file.ext')]
     assert action.defer_call(c_name, c_version, c_action, files=files) == action
     tr_files = transport.get(files_path, delimiter='|')
-    assert isinstance(tr_files, dict)
+    assert isinstance(tr_files, list)
     assert len(tr_files) == 1
-    assert 'download' in tr_files
-    assert tr_files['download'] == {
+    assert tr_files[0] == {
+        FIELD_MAPPINGS['name']: 'download',
         FIELD_MAPPINGS['token']: '',
         FIELD_MAPPINGS['filename']: 'file.ext',
         FIELD_MAPPINGS['size']: 0,
@@ -706,10 +706,10 @@ def test_api_action_call_remote(read_json, registry):
     kwargs['files'] = [action.new_file('download', '/tmp/file.ext')]
     assert action.remote_call(**kwargs) == action
     tr_files = transport.get(files_path, delimiter='|')
-    assert isinstance(tr_files, dict)
+    assert isinstance(tr_files, list)
     assert len(tr_files) == 1
-    assert 'download' in tr_files
-    assert tr_files['download'] == {
+    assert tr_files[0] == {
+        FIELD_MAPPINGS['name']: 'download',
         FIELD_MAPPINGS['token']: '',
         FIELD_MAPPINGS['filename']: 'file.ext',
         FIELD_MAPPINGS['size']: 0,

--- a/tests/api/test_file.py
+++ b/tests/api/test_file.py
@@ -27,6 +27,7 @@ def test_api_file_to_payload():
 
 def test_api_payload_to_file():
     values = {
+        'name': 'foo',
         'path': 'http://127.0.0.1:8080/ANBDKAD23142421',
         'mime': 'application/json',
         'filename': 'file.json',
@@ -35,7 +36,7 @@ def test_api_payload_to_file():
         }
     payload = {FIELD_MAPPINGS[name]: value for name, value in values.items()}
 
-    file = payload_to_file('foo', payload)
+    file = payload_to_file(payload)
     assert file is not None
     assert file.get_name() == 'foo'
 

--- a/tests/data/transport.json
+++ b/tests/data/transport.json
@@ -12,6 +12,7 @@
     }
   },
   "b": {
+    "n": "download",
     "p": "file:///tmp/document.pdf",
     "f": "document.pdf",
     "s": 1234567890,
@@ -21,21 +22,22 @@
     "http://127.0.0.1:80": {
       "users": {
         "1.0.0": {
-          "create": {
-            "avatar": {
+          "create": [
+            {
+              "n": "avatar",
               "p": "http://12.34.56.78:1234/files/ac3bd4b8-7da3-4c40-8661-746adfa55e0d",
               "t": "fb9an6c46be74s425010896fcbd99e2a",
               "f": "smiley.jpg",
               "s": 1234567890,
               "m": "image/jpeg"
-            },
-            "document": {
+            }, {
+              "n": "document",
               "p": "file:///tmp/document.pdf",
               "f": "document.pdf",
               "s": 1234567890,
               "m": "application/pdf"
             }
-          }
+          ]
         }
       }
     }


### PR DESCRIPTION
## Changed
- Running a service with an action input payload now flushes the output right after the print.
- File payload have a name and is now added to transport as a list of files instead of a dict.