### PR TITLE
Version update to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - A configured file server must be available to make runtime calls
   that send file parameters.
 
+### Changed
+- Calls to `Api.done()` raise an exception now.
+
 ## [1.3.0] - 2017-11-01
 ### Added
 - Support for action tags defined in the configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- A configured file server must be available to make runtime calls
+  that send file parameters.
 
 ## [1.3.0] - 2017-11-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.3.1] - 2017-11-03
 ### Added
 - A configured file server must be available to make runtime calls
   that send file parameters.

--- a/katana/__init__.py
+++ b/katana/__init__.py
@@ -12,4 +12,4 @@ file that was distributed with this source code.
 
 __license__ = "MIT"
 __copyright__ = "Copyright (c) 2016-2017 KUSANAGI S.L. (http://kusanagi.io)"
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/katana/api/action.py
+++ b/katana/api/action.py
@@ -531,8 +531,8 @@ class Action(Api):
 
         # Check if there are mappings to validate.
         # Note: When action is run from CLI mappings will be ampty.
-        if self._schema.has_mappings:
-            if not get_path(self._schema.get(path), 'files', False):
+        if self._registry.has_mappings:
+            if not get_path(self._registry.get(path), 'files', False):
                 raise NoFileServerError(service, version)
 
         self.__transport.set('body', file_to_payload(file))
@@ -903,13 +903,27 @@ class Action(Api):
 
         # Get address for current action's service
         path = '/'.join([self.get_name(), self.get_version(), 'address'])
-        address = self._schema.get(path, None)
+        address = self._registry.get(path, None)
         if not address:
             msg = 'Failed to get address for Service: "{}" ({})'.format(
                 self.get_name(),
                 self.get_version(),
                 )
             raise ApiError(msg)
+
+        # Check that files are supported by the service if local files are used
+        files = kwargs.get('files')
+        if files:
+            for file in files:
+                if not file.is_local():
+                    continue
+
+                # A local file is included in the files list
+                if self.__schema and self.__schema.has_file_server():
+                    # Files are supported
+                    break
+
+                raise NoFileServerError(self.get_name(), self.get_version())
 
         transport, result = runtime_call(
             address,

--- a/katana/api/base.py
+++ b/katana/api/base.py
@@ -221,4 +221,6 @@ class Api(object):
 
         """
 
-        return False
+        raise ApiError(
+            'SDK does not support async call to end action: Api.done()'
+            )

--- a/katana/api/base.py
+++ b/katana/api/base.py
@@ -35,7 +35,7 @@ class Api(object):
         self.__framework_version = framework_version
         self.__variables = kw.get('variables') or {}
         self.__debug = kw.get('debug', False)
-        self._schema = get_schema_registry()
+        self._registry = get_schema_registry()
         self._component = component
         # Logger must be initialized by child classes
         self._logger = None
@@ -155,8 +155,8 @@ class Api(object):
         """
 
         services = []
-        for name in self._schema.get_service_names():
-            for version in self._schema.get(name).keys():
+        for name in self._registry.get_service_names():
+            for version in self._registry.get(name).keys():
                 services.append({'name': name, 'version': version})
 
         return services
@@ -182,17 +182,17 @@ class Api(object):
         if '*' in version:
             try:
                 version = VersionString(version).resolve(
-                    self._schema.get(name, {}).keys()
+                    self._registry.get(name, {}).keys()
                     )
                 # NOTE: Space is uses ad separator because service names allow
                 #       any character except spaces, \t or \n.
                 path = '{} {}'.format(name, version)
-                payload = self._schema.get(path, None, delimiter=" ")
+                payload = self._registry.get(path, None, delimiter=" ")
             except KatanaError:
                 payload = None
         else:
             path = '{} {}'.format(name, version)
-            payload = self._schema.get(path, None, delimiter=" ")
+            payload = self._registry.get(path, None, delimiter=" ")
 
         if not payload:
             error = 'Cannot resolve schema for Service: "{}" ({})'

--- a/katana/server.py
+++ b/katana/server.py
@@ -83,7 +83,7 @@ class ComponentServer(object):
 
         self.__args = args
         self.__socket = None
-        self.__schema_registry = get_schema_registry()
+        self.__registry = get_schema_registry()
 
         # Check the first callback to see if asyncio is being used,
         # otherwise callbacks are standard python callables.
@@ -206,7 +206,7 @@ class ComponentServer(object):
 
         LOG.debug('Updating schemas for Services ...')
         try:
-            self.__schema_registry.update_registry(unpack(stream))
+            self.__registry.update_registry(unpack(stream))
         except asyncio.CancelledError:
             raise
         except:


### PR DESCRIPTION
### Added
- A configured file server must be available to make runtime calls that send file parameters.

### Changed
- Calls to `Api.done()` raise an exception now.